### PR TITLE
fix: Broken tag filter on pagination due to incorrect value formatting

### DIFF
--- a/community/templates/community/question/list.html
+++ b/community/templates/community/question/list.html
@@ -77,7 +77,7 @@
           {% if page_obj.has_previous %}
             <li class="page-item">
               <a class="page-link"
-                 href="?page=1&q={{ filterset.form.q.value|default_if_none:'' }}&tag={{ filterset.form.tag.value|join:','|urlencode }}">&laquo; First</a>
+                 href="?page=1&q={{ filterset.form.q.value|default_if_none:'' }}&tag={{ filterset.form.tag.value|default_if_none:'' }}">&laquo; First</a>
             </li>
             <li class="page-item">
               <a class="page-link"
@@ -97,11 +97,11 @@
           {% if page_obj.has_next %}
             <li class="page-item">
               <a class="page-link"
-                 href="?page={{ page_obj.next_page_number }}&q={{ filterset.form.q.value|default_if_none:'' }}&tag={{ filterset.form.tag.value|join:','|urlencode }}">Next</a>
+                 href="?page={{ page_obj.next_page_number }}&q={{ filterset.form.q.value|default_if_none:'' }}&tag={{ filterset.form.tag.value|default_if_none:'' }}">Next</a>
             </li>
             <li class="page-item">
               <a class="page-link"
-                 href="?page={{ page_obj.paginator.num_pages }}&q={{ filterset.form.q.value|default_if_none:'' }}&tag={{ filterset.form.tag.value|join:','|urlencode }}">Last &raquo;</a>
+                 href="?page={{ page_obj.paginator.num_pages }}&q={{ filterset.form.q.value|default_if_none:'' }}&tag={{ filterset.form.tag.value|default_if_none:'' }}">Last &raquo;</a>
             </li>
           {% else %}
             <li class="page-item disabled">


### PR DESCRIPTION
fix: tag filter was broken on pagination due to split values in URL

- Before: When clicking to the next page, the tag filter stopped working.
- Cause: `tag.value|join:","` converted the tag list into a comma-separated string (`?tag=t,a,g`), breaking the filter.
- Fix: Replaced it with `tag.value|default_if_none:''` to pass the correct tag name as a whole.
- Result: Pagination now keeps the tag filter and works as expected across all pages.
