### PR TITLE
fix: search query with special characters broke on tag filter

### DIFF
--- a/community/templates/community/question/list.html
+++ b/community/templates/community/question/list.html
@@ -4,7 +4,7 @@
   <div class="container my-5">
     <h1 class="mb-4 text-center">All Questions</h1>
     <form method="get" class="row g-3 align-items-end mb-4">
-      <div class="col-md-4">
+      <div class="col-md-5">
         <label for="searchQuery" class="form-label">Search</label>
         <input type="text"
                id="searchQuery"
@@ -34,12 +34,6 @@
           <div class="btn btn-warning w-100">Ask Question</div>
         </a>
       </div>
-      {% if filterset.form.tag.value or filterset.form.q.value %}
-        <div class="btn btn-danger col-md-1 rounded">
-          <a href="{% url 'question_list' %}"
-             class="text-decoration-none text-white">Clear filters</a>
-        </div>
-      {% endif %}
     </form>
     {% if question_list %}
       <div class="row">
@@ -48,7 +42,7 @@
             <div class="card shadow-sm">
               <div class="card-body">
                 <div class="d-flex justify-content-between align-items-center mb-2">
-                  <a href="{% url 'question_detail' question.id %}"
+                  <a href="{% url "question_detail" question.id %}"
                      class="text-decoration-none">
                     <h5 class="card-title mb-0">{{ question.title }}</h5>
                   </a>
@@ -74,8 +68,7 @@
       </div>
     {% else %}
       <div class="alert alert-info">
-        No questions found matching your filters.
-        <a href="{% url 'question_list' %}">Clear filters</a>
+        No questions found matching your filters. <a href="{% url 'question_list' %}">Clear filters</a>
       </div>
     {% endif %}
     {% if is_paginated %}

--- a/community/templates/community/question/list.html
+++ b/community/templates/community/question/list.html
@@ -42,7 +42,7 @@
             <div class="card shadow-sm">
               <div class="card-body">
                 <div class="d-flex justify-content-between align-items-center mb-2">
-                  <a href="{% url "question_detail" question.id %}"
+                  <a href="{% url 'question_detail' question.id %}"
                      class="text-decoration-none">
                     <h5 class="card-title mb-0">{{ question.title }}</h5>
                   </a>
@@ -52,7 +52,7 @@
                 {% if question.tags.all %}
                   <div class="mt-2">
                     {% for tag in question.tags.all %}
-                      <a href="?q={{ filterset.form.q.value|default_if_none:'' }}&tag={{ tag.name }}"
+                      <a href="?q={{ filterset.form.q.value|default_if_none:''|urlencode }}&tag={{ tag.name|urlencode }}"
                          class="text-decoration-none">
                         <span class="badge mx-1 {% if tag.name in filterset.form.tag.value %}bg-primary{% else %}bg-secondary{% endif %}">
                           {{ tag.name }}
@@ -68,7 +68,8 @@
       </div>
     {% else %}
       <div class="alert alert-info">
-        No questions found matching your filters. <a href="{% url 'question_list' %}">Clear filters</a>
+        No questions found matching your filters.
+        <a href="{% url 'question_list' %}">Clear filters</a>
       </div>
     {% endif %}
     {% if is_paginated %}
@@ -77,11 +78,11 @@
           {% if page_obj.has_previous %}
             <li class="page-item">
               <a class="page-link"
-                 href="?page=1&q={{ filterset.form.q.value|default_if_none:'' }}&tag={{ filterset.form.tag.value|default_if_none:'' }}">&laquo; First</a>
+                 href="?page=1&q={{ filterset.form.q.value|default_if_none:''|urlencode }}&tag={{ filterset.form.tag.value|default_if_none:''|urlencode }}">&laquo; First</a>
             </li>
             <li class="page-item">
               <a class="page-link"
-                 href="?page={{ page_obj.previous_page_number }}&q={{ filterset.form.q.value|default_if_none:'' }}&tag={{ filterset.form.tag.value|join:','|urlencode }}">Previous</a>
+                 href="?page={{ page_obj.previous_page_number }}&q={{ filterset.form.q.value|default_if_none:''|urlencode }}&tag={{ filterset.form.tag.value|default_if_none:''|urlencode }}">Previous</a>
             </li>
           {% else %}
             <li class="page-item disabled">
@@ -97,11 +98,11 @@
           {% if page_obj.has_next %}
             <li class="page-item">
               <a class="page-link"
-                 href="?page={{ page_obj.next_page_number }}&q={{ filterset.form.q.value|default_if_none:'' }}&tag={{ filterset.form.tag.value|default_if_none:'' }}">Next</a>
+                 href="?page={{ page_obj.next_page_number }}&q={{ filterset.form.q.value|default_if_none:''|urlencode }}&tag={{ filterset.form.tag.value|default_if_none:''|urlencode }}">Next</a>
             </li>
             <li class="page-item">
               <a class="page-link"
-                 href="?page={{ page_obj.paginator.num_pages }}&q={{ filterset.form.q.value|default_if_none:'' }}&tag={{ filterset.form.tag.value|default_if_none:'' }}">Last &raquo;</a>
+                 href="?page={{ page_obj.paginator.num_pages }}&q={{ filterset.form.q.value|default_if_none:''|urlencode }}&tag={{ filterset.form.tag.value|default_if_none:''|urlencode }}">Last &raquo;</a>
             </li>
           {% else %}
             <li class="page-item disabled">

--- a/community/templates/community/question/list.html
+++ b/community/templates/community/question/list.html
@@ -4,7 +4,7 @@
   <div class="container my-5">
     <h1 class="mb-4 text-center">All Questions</h1>
     <form method="get" class="row g-3 align-items-end mb-4">
-      <div class="col-md-5">
+      <div class="col-md-4">
         <label for="searchQuery" class="form-label">Search</label>
         <input type="text"
                id="searchQuery"
@@ -34,6 +34,12 @@
           <div class="btn btn-warning w-100">Ask Question</div>
         </a>
       </div>
+      {% if filterset.form.tag.value or filterset.form.q.value %}
+        <div class="btn btn-danger col-md-1 rounded">
+          <a href="{% url 'question_list' %}"
+             class="text-decoration-none text-white">Clear filters</a>
+        </div>
+      {% endif %}
     </form>
     {% if question_list %}
       <div class="row">

--- a/community/templates/community/question/list.html
+++ b/community/templates/community/question/list.html
@@ -77,7 +77,7 @@
           {% if page_obj.has_previous %}
             <li class="page-item">
               <a class="page-link"
-                 href="?page=1&q={{ filterset.form.q.value|default_if_none:'' }}&tag={{ filterset.form.tag.value|join:','|urlencode }}">&laquo; First</a>
+                 href="?page=1&q={{ filterset.form.q.value|default_if_none:'' }}&tag={{ filterset.form.tag.value|default_if_none:'' }}">&laquo; First</a>
             </li>
             <li class="page-item">
               <a class="page-link"
@@ -97,11 +97,11 @@
           {% if page_obj.has_next %}
             <li class="page-item">
               <a class="page-link"
-                 href="?page={{ page_obj.next_page_number }}&q={{ filterset.form.q.value|default_if_none:'' }}&tag={{ filterset.form.tag.value|join:','|urlencode }}">Next</a>
+                 href="?page={{ page_obj.next_page_number }}&q={{ filterset.form.q.value|default_if_none:'' }}&tag={{ filterset.form.tag.value|default_if_none:'' }}">Next</a>
             </li>
             <li class="page-item">
               <a class="page-link"
-                 href="?page={{ page_obj.paginator.num_pages }}&q={{ filterset.form.q.value|default_if_none:'' }}&tag={{ filterset.form.tag.value|join:','|urlencode }}">Last &raquo;</a>
+                 href="?page={{ page_obj.paginator.num_pages }}&q={{ filterset.form.q.value|default_if_none:'' }}&tag={{ filterset.form.tag.value|default_if_none:'' }}">Last &raquo;</a>
             </li>
           {% else %}
             <li class="page-item disabled">


### PR DESCRIPTION
fix: search query with special characters broke on tag filter

- Before: When the search input contained `#` or other special characters, clicking a tag caused the query to break.
- Cause: The `q` and `tag` values were not URL-encoded, so `#` was treated as a URL fragment, cutting off the actual query.
- Fix: Applied `urlencode` to both `q` and `tag` in all filter and pagination links.
- Now: Search with special characters works correctly with tag filtering.
