### PR TITLE
feat: Show score and number of answers in the question list page

### DIFF
--- a/community/templates/community/question/list.html
+++ b/community/templates/community/question/list.html
@@ -73,7 +73,7 @@
                       <small class="text-muted d-block">{{ question.created_at|date:"M d, Y" }}</small>
                       <small class="text-muted">{{ question.answer_count }} answer{{ question.answer_count|pluralize }}</small>
                     </div>
-                    <div class="mt-2">{{ question.score }} vote{{ question.score|pluralize }}</div>
+                    <small class="mt-2 text-muted">{{ question.score }} vote{{ question.score|pluralize }}</small>
                   </div>
                 </div>
               </div>

--- a/community/templates/community/question/list.html
+++ b/community/templates/community/question/list.html
@@ -69,7 +69,11 @@
                     {% endif %}
                   </div>
                   <div class="text-end">
-                    <small class="text-muted d-block">{{ question.created_at|date:"M d, Y" }}</small>
+                    <div class="mb-1">
+                      <small class="text-muted d-block">{{ question.created_at|date:"M d, Y" }}</small>
+                      <small class="text-muted">{{ question.answer_count }} answer{{ question.answer_count|pluralize }}</small>
+                    </div>
+                    <div class="mt-2">{{ question.score }} vote{{ question.score|pluralize }}</div>
                   </div>
                 </div>
               </div>

--- a/community/views.py
+++ b/community/views.py
@@ -15,7 +15,7 @@ from django.views.generic import (
 )
 from django.views.generic.edit import FormMixin
 from taggit.models import Tag
-from django.db.models import Sum
+from django.db.models import Count, Sum
 from community.forms import AnswerForm, CommentForm, QuestionForm
 from .filters import QuestionFilter
 from .models import Answer, Comment, Question, Vote
@@ -28,7 +28,7 @@ class QuestionListView(LoginRequiredMixin, ListView):
     paginate_by = 10
 
     def get_queryset(self):
-        queryset = super().get_queryset()
+        queryset = super().get_queryset().annotate(answer_count=Count("answers"))
         self.filterset = QuestionFilter(self.request.GET, queryset=queryset)
         return self.filterset.qs.distinct()
 


### PR DESCRIPTION
- Previously, the question list page did not show scores or number of answers per question.
- This update adds and displays those scores and counts for each question.